### PR TITLE
Link Bluefin docs to replace reference page

### DIFF
--- a/src/content/docs/reference/example.md
+++ b/src/content/docs/reference/example.md
@@ -1,11 +1,6 @@
 ---
-title: Example Reference
-description: A reference page in my new Starlight docs site.
+title: Bluefin Documentation
+description: A useful reference for Aurora outside of GNOME specific details.
 ---
 
-Reference pages are ideal for outlining how things work in terse and clear terms.
-Less concerned with telling a story or addressing a specific use case, they should give a comprehensive outline of what you're documenting.
-
-## Further reading
-
-- Read [about reference](https://diataxis.fr/reference/) in the Diátaxis framework
+[Bluefin Documentation](https://docs.projectbluefin.io/) has relevant information for Aurora outside of the GNOME specific documentation.


### PR DESCRIPTION
This is an optional PR to replace the reference page with a link to the Bluefin documentation since both will share similar information outside of desktop environment specifics.